### PR TITLE
Django Rest Framework installation and initial configuration

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import DefaultRouter
+
+router = DefaultRouter()
+
+urlpatterns = []
+
+urlpatterns.extend(router.urls)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework'
 ]
 
 MIDDLEWARE = [
@@ -48,6 +49,15 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ]
+}
 
 ROOT_URLCONF = 'config.urls'
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('api.urls')),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 django
+djangorestframework
 psycopg
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,17 @@
 asgiref==3.7.2
     # via django
 django==4.2.6
+    # via
+    #   -r requirements.in
+    #   djangorestframework
+djangorestframework==3.14.0
     # via -r requirements.in
 psycopg==3.1.12
     # via -r requirements.in
 python-dotenv==1.0.0
     # via -r requirements.in
+pytz==2023.3.post1
+    # via djangorestframework
 sqlparse==0.4.4
     # via django
 typing-extensions==4.8.0


### PR DESCRIPTION
- Add `djangorestframework` to `requirements.txt`
- Add `rest_framework` to installed apps
- Add global `AUTHENTICATION_CLASSES` and `PERMISSION_CLASSES` for DRF endpoints to settings
     - All DRF endpoints will use `SessionAuthentication` and require that the user `IsAuthenticated`, unless the attributes `authentication_classes` and `permission_classes` are overridden in an individual DRF view.
- Create `urls.py` for `api` with `DefaultRouter` (which gives us a browsable API at root)
     - Additional endpoints will go in the empty `urlpatterns` list (unless they use `ViewSet`s)
- Include `api/urls` in project `urls.py`

Closes #9 