### PR TITLE
Create API endpoint for user signup

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,34 +1,10 @@
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.shortcuts import get_object_or_404
 
-from rest_framework.exceptions import AuthenticationFailed, ValidationError
-from rest_framework.serializers import Serializer, ModelSerializer, CharField, EmailField, UUIDField
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.serializers import CharField, EmailField, ModelSerializer, Serializer, UUIDField
 
-from api.models import VaultItem, VaultCollection
-
-
-class LoginSerializer(Serializer):
-    email = EmailField(required=True)
-    password = CharField(required=True)
-
-    def validate(self, data):
-        email = data.get('email')
-        password = data.get('password')
-
-        user = authenticate(request=self.context.get('request'),
-                            email=email,
-                            password=password)
-        if user is None:
-            raise AuthenticationFailed('Invalid email or password')
-
-        data['user'] = user
-        return data
-
-
-class VaultItemSerializer(ModelSerializer):
-    class Meta:
-        model = VaultItem
-        fields = '__all__'
+from api.models import UserKey, VaultItem, VaultCollection
 
 
 class CreateVaultItemSerializer(Serializer):
@@ -50,3 +26,44 @@ class CreateVaultItemSerializer(Serializer):
             'encrypted_data': data.get('encrypted_data'),
             'vault_collection_id': vault_collection.id
         }
+
+
+class LoginSerializer(Serializer):
+    email = EmailField(required=True)
+    password = CharField(required=True)
+
+    def validate(self, data):
+        email = data.get('email')
+        password = data.get('password')
+
+        user = authenticate(request=self.context.get('request'),
+                            email=email,
+                            password=password)
+        if user is None:
+            raise AuthenticationFailed('Invalid email or password')
+
+        data['user'] = user
+        return data
+
+
+class SignupSerializer(ModelSerializer):
+    encrypted_symmetric_key = CharField(required=True)
+
+    class Meta:
+        model = get_user_model()
+        fields = ['email', 'password', 'encrypted_symmetric_key']
+
+    def save(self):
+        user = get_user_model().objects.create_user(email=self.validated_data['email'],
+                                                    password=self.validated_data['password'])
+        UserKey.objects.create(
+            user=user,
+            encrypted_symmetric_key=self.validated_data['encrypted_symmetric_key']
+        )
+        return user
+
+
+class VaultItemSerializer(ModelSerializer):
+    class Meta:
+        model = VaultItem
+        fields = '__all__'

--- a/api/tests/test_signup.py
+++ b/api/tests/test_signup.py
@@ -1,0 +1,136 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework.test import APITestCase
+
+from api.models import UserKey
+
+
+class TestSignupAPIView(APITestCase):
+
+    def setUp(self):
+        self.login_url = reverse('login')
+        self.signup_url = reverse('signup')
+        self.user_data = {
+            'email': 'bob@example.com',
+            'password': 'super-password',
+            'encrypted_symmetric_key': 'aV7XEg4EaWIivTcS76QcXPg7qD/'
+                                       'Kox7MdAU44pQwKrfPKqb2Yl5/7CcAzC7dqQf9PyelHwM0oSeY52T7'
+        }
+
+    def test_signup_success(self):
+        response = self.client.post(self.signup_url, self.user_data)
+        self.assertEqual(response.status_code, 201)
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 1)
+        user_keys = UserKey.objects.filter(user=users[0])
+        self.assertEqual(len(user_keys), 1)
+        user_key = user_keys[0]
+        self.assertEqual(user_key.encrypted_symmetric_key,
+                         self.user_data['encrypted_symmetric_key'])
+
+    def test_signed_up_user_can_log_in(self):
+        self.client.post(self.signup_url, self.user_data)
+        response = self.client.post(self.login_url, {
+            'email': self.user_data['email'],
+            'password': self.user_data['password']
+        })
+        self.assertEqual(response.status_code, 200)
+
+    def test_signup_email_already_exists(self):
+        self.client.post(self.signup_url, self.user_data)
+        response = self.client.post(self.signup_url, self.user_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('user with this email already exists.', response.data['email'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 1)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 1)
+
+    def test_signup_email_missing(self):
+        response = self.client.post(self.signup_url, {
+            'password': self.user_data['password'],
+            'encrypted_symmetric_key': self.user_data['encrypted_symmetric_key']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field is required.', response.data['email'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_password_missing(self):
+        response = self.client.post(self.signup_url, {
+            'email': self.user_data['email'],
+            'encrypted_symmetric_key': self.user_data['encrypted_symmetric_key']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field is required.', response.data['password'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_encrypted_symmetric_key_missing(self):
+        response = self.client.post(self.signup_url, {
+            'email': self.user_data['email'],
+            'password': self.user_data['password']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field is required.', response.data['encrypted_symmetric_key'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_email_invalid(self):
+        response = self.client.post(self.signup_url, {
+            'email': 'bob',
+            'password': self.user_data['password'],
+            'encrypted_symmetric_key': self.user_data['encrypted_symmetric_key']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Enter a valid email address.', response.data['email'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_email_blank(self):
+        response = self.client.post(self.signup_url, {
+            'email': '',
+            'password': self.user_data['password'],
+            'encrypted_symmetric_key': self.user_data['encrypted_symmetric_key']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field may not be blank.', response.data['email'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_password_blank(self):
+        response = self.client.post(self.signup_url, {
+            'email': self.user_data['email'],
+            'password': '',
+            'encrypted_symmetric_key': self.user_data['encrypted_symmetric_key']
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field may not be blank.', response.data['password'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)
+
+    def test_signup_encrypted_symmetric_key_blank(self):
+        response = self.client.post(self.signup_url, {
+            'email': self.user_data['email'],
+            'password': self.user_data['password'],
+            'encrypted_symmetric_key': ''
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('This field may not be blank.', response.data['encrypted_symmetric_key'])
+        users = get_user_model().objects.all()
+        self.assertEqual(len(users), 0)
+        user_keys = UserKey.objects.all()
+        self.assertEqual(len(user_keys), 0)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,17 +1,15 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
-from django.urls import path
-from .views import VaultItemAPIView
 
-from .views import LoginAPIView, LogoutAPIView, TestView
+from .views import LoginAPIView, LogoutAPIView, SignupAPIView, VaultItemAPIView
 
 router = DefaultRouter()
 
 urlpatterns = [
+    path('api/vault_item/', VaultItemAPIView.as_view(), name='vault_item'),
     path('login/', LoginAPIView.as_view(), name='login'),
     path('logout/', LogoutAPIView.as_view(), name='logout'),
-    path('test/', TestView.as_view(), name='test'),
-    path('api/vault_item/', VaultItemAPIView.as_view(), name='vault_item'),
+    path('signup/', SignupAPIView.as_view(), name='signup'),
 ]
 
 urlpatterns.extend(router.urls)

--- a/api/views.py
+++ b/api/views.py
@@ -1,11 +1,13 @@
-from django.contrib.auth import login, logout
+from django.contrib.auth import get_user_model, login, logout
 
 from rest_framework import status
+from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import LoginSerializer, CreateVaultItemSerializer, VaultItemSerializer
+from .serializers import LoginSerializer, CreateVaultItemSerializer, SignupSerializer,\
+    VaultItemSerializer
 
 
 class LoginAPIView(APIView):
@@ -29,11 +31,12 @@ class LogoutAPIView(APIView):
         return Response(status=status.HTTP_200_OK)
 
 
-class TestView(APIView):
+class SignupAPIView(CreateAPIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
 
-    def get(self, request):  # noqa
-        return Response(data={'detail': 'Congratulations! You are an authenticated user!'},
-                        status=status.HTTP_200_OK)
+    model = get_user_model()
+    serializer_class = SignupSerializer
 
 
 class VaultItemAPIView(APIView):


### PR DESCRIPTION
## Changes

- Implement `/signup/` API endpoint
  - Validates that no existing user has the same email
  - Validates that email is in the correct format
  - Validates that all required fields are present and not blank:
       - email
       - password
       - encrypted_symmetric_key
  - Creates new `User` and associated `UserKey` objects
 
## Testing

- Unit tests
- Manual testing with Postman:

1. Sign up new user

<img width="772" alt="Screenshot 2023-11-03 at 7 03 46 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/3a4a45f7-5668-4742-82fe-9defc3841037">

2. Log in using the new user's credentials

<img width="774" alt="Screenshot 2023-11-03 at 7 04 14 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/93d0e0ac-4a7a-4ee6-b981-f27607f3a5e8">


Closes #11 