### PR TITLE
Configure CORS, CSRF, SESSION_COOKIE settings to allow cross-origin authentication

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -137,3 +138,10 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_COOKIE_SAMESITE = 'Lax'
+
+SESSION_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_HTTPONLY = True

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -3,3 +3,12 @@ from .base import *
 ALLOWED_HOSTS = ['localhost']
 
 DEBUG = True
+
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:5173',
+    'http://127.0.0.1:5173'
+]
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:5173',
+    'http://127.0.0.1:5173'
+]

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,5 +1,18 @@
 from .base import *
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['.key-fortress.com']
 
 DEBUG = False
+
+CORS_ALLOWED_ORIGINS = [
+    'https://key-fortress.com',
+    "https://www.key-fortress.com"
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'https://key-fortress.com',
+    "https://www.key-fortress.com"
+]
+
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 django
+django-cors-headers
 djangorestframework
 psycopg
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,10 @@ asgiref==3.7.2
 django==4.2.6
     # via
     #   -r requirements.in
+    #   django-cors-headers
     #   djangorestframework
+django-cors-headers==4.3.0
+    # via -r requirements.in
 djangorestframework==3.14.0
     # via -r requirements.in
 psycopg==3.1.12


### PR DESCRIPTION
This PR makes changes to the Django app configuration which will allow the frontend to send requests to and authenticate with the backend, even though they're on separate origins.

## Changes

- Install `django-cors-headers` library to [add Cross-Origin Resource Sharing (CORS) headers to responses](https://pypi.org/project/django-cors-headers/).
- Add `CorsMiddleware` to Django `MIDDLEWARE` list so that it can add headers to responses.
- Add frontend dev and prod origins to `CORS_ALLOWED_ORIGINS`, which will allow the frontend to make requests to the backend.
- Add frontend dev and prod origins to `CSRF_TRUSTED_ORIGINS`, which will allow the frontend to use CSRF tokens.
- Allow session cookies to be included in cross-site requests by setting `CORS_ALLOW_CREDENTIALS` to True.
- Set `SESSION_COOKIE_SAMESITE` and `CSRF_COOKIE_SAMESITE` to `Lax`, so that the `sessionid` and `csrftoken` cookies are set on the client.
- Set `SESSION_COOKIE_HTTPONLY` to `True` so that the `sessionid` cookie is not available from client Javascript.
- On prod settings only, set `SESSION_COOKIE_SECURE` and `CSRF_COOKIE_SECURE` to `True` so that they can only be sent over HTTPS.

## Testing

In a new branch of the frontend project, I placed the following code inside the Dashboard component, to test whether cross-origin requests and authentication would succeed. The code just logs a user in, then immediately logs them out.

Logging a user in does not require the session or CSRF cookies, but the logout endpoint requires both. 

In the fetch requests, the sessionid is set and returned by using `credentials: "include"`, and the CSRF cookie is passed in the `X-CSRFToken` header after it's grabbed from the DOM using the `getCookie` helper method (there are also JS libraries that can do this).

```js

// Above DashboardPage definition

// This code comes from the Django documentation: https://docs.djangoproject.com/en/4.2/howto/csrf/#using-csrf-protection-with-ajax

function getCookie(name) {
    let cookieValue = null;
    if (document.cookie && document.cookie !== '') {
        const cookies = document.cookie.split(';');
        for (let i = 0; i < cookies.length; i++) {
            const cookie = cookies[i].trim();
            // Does this cookie string begin with the name we want?
            if (cookie.substring(0, name.length + 1) === (name + '=')) {
                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
                break;
            }
        }
    }
    return cookieValue;
}

// Inside of DashboardPage function

useEffect(() => {
    fetch('http://localhost:8000/login/', {
        method: "POST",
        headers: {
            "Accept": "application/json",
            "Content-Type": "application/json"
        },
        credentials: "include",
        body: JSON.stringify({
            email: "bob@example.com",
            password: "sase0nv8a8es97/nvraesajcrac78sec="
        })
    }).then(response => {
        console.log(response.status);
        const csrfToken = getCookie('csrftoken');
        fetch('http://localhost:8000/logout/', {
            method: "POST",
            headers: {
                "Accept": "application/json",
                "Content-Type": "application/json",
                "X-CSRFToken": csrfToken
            },
            credentials: "include"
        }).then(response => {
            console.log(response.status)
        })
    })
}, [])
```

Without any changes to the Django project, the request to `/login/` results in a CORS error:

<img width="733" alt="Screenshot 2023-11-07 at 1 58 50 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/1a777f9b-d4c9-4d36-b07a-11db7af6acfd">

After making the CORS config changes to the Django project the request to `/login/` succeeds, but the request to '/logout/' fails, since the frontend is not in the list of CSRF Trusted Origins:

<img width="478" alt="Screenshot 2023-11-07 at 2 01 54 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/cfb1c6c2-9917-47e9-af42-7613204e1c4e">

<img width="764" alt="Screenshot 2023-11-07 at 2 02 20 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/fe7ac12f-a9dd-4831-931b-80c9b29d2572">

After making the rest of the changes, both requests succeed:

<img width="194" alt="Screenshot 2023-11-07 at 2 06 50 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/656ca9f6-54c0-4bfb-b76d-0c2a30ce36ef">

<img width="271" alt="Screenshot 2023-11-07 at 2 06 29 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/122c2afa-2a03-47f3-8140-466cde727125">

<img width="261" alt="Screenshot 2023-11-07 at 2 06 41 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/ef57b648-3efe-43cf-9cc7-c7457bdae112">


Closes #31 