### PR TITLE
Add UserKey, VaultItem, and VaultCollection models to admin site

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,6 +1,24 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from .models import User
+from .models import User, UserKey, VaultItem, VaultCollection
+
+
+class UserKeyInline(admin.TabularInline):
+    model = UserKey
+    readonly_fields = ('created_at', 'modified_at')
+
+
+class VaultCollectionInline(admin.TabularInline):
+    model = VaultCollection
+    readonly_fields = ('uuid',)
+    show_change_link = True
+    extra = 0
+
+
+class VaultItemInline(admin.TabularInline):
+    model = VaultItem
+    readonly_fields = ('uuid', 'created_at', 'modified_at',)
+    extra = 0
 
 
 class UserAdmin(BaseUserAdmin):
@@ -20,6 +38,28 @@ class UserAdmin(BaseUserAdmin):
     list_filter = ('is_staff', 'is_superuser', 'is_active', 'groups')
     search_fields = ('email',)
     ordering = ('email',)
+    inlines = (UserKeyInline, VaultCollectionInline,)
+
+
+class UserKeyAdmin(admin.ModelAdmin):
+    ordering = ('user',)
+    search_fields = ('user',)
+    list_display = ('user', 'encrypted_symmetric_key', 'created_at', 'modified_at',)
+
+
+class VaultCollectionAdmin(admin.ModelAdmin):
+    ordering = ('name',)
+    search_fields = ('name',)
+    list_display = ('name', 'uuid',)
+    inlines = (VaultItemInline,)
+
+
+class VaultItemAdmin(admin.ModelAdmin):
+    ordering = ('modified_at',)
+    list_display = ('encrypted_data', 'uuid', 'created_at', 'modified_at',)
 
 
 admin.site.register(User, UserAdmin)
+admin.site.register(UserKey, UserKeyAdmin)
+admin.site.register(VaultCollection, VaultCollectionAdmin)
+admin.site.register(VaultItem, VaultItemAdmin)

--- a/api/models.py
+++ b/api/models.py
@@ -59,6 +59,9 @@ class UserKey(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     modified_at = models.DateTimeField(auto_now=True)
 
+    def __str__(self):
+        return f"User key for {self.user.email}"
+
 
 class VaultCollection(models.Model):
     user = models.ForeignKey(
@@ -67,6 +70,9 @@ class VaultCollection(models.Model):
     )
     name = models.CharField()
     uuid = models.UUIDField(primary_key=False, default=uuid.uuid4, editable=False)
+
+    def __str__(self):
+        return self.name
 
 
 class VaultItem(models.Model):


### PR DESCRIPTION
This PR adds pages for the UserKey, VaultItem, and VaultCollection models to the admin site.

This is more of a development tool - it allows you to create and update database rows without having to go through a separate application.

Users created through the admin will have their passwords correctly hashed, unlike users added by using raw SQL through a separate database client.

## Changes

- Add UserKey, VaultItem, VaultCollection admin pages
- Add VaultItem inline to VaultCollection detail page
- Add VaultCollection and UserKey inlines to User detail page

## Screenshots

Root admin menu showing model admin pages

<img width="686" alt="Screenshot 2023-11-08 at 4 53 31 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/aa51fc08-0543-43c8-a6f2-93f27fcec3b4">

VaultItem inline at bottom of VaultCollection detail page

<img width="1188" alt="Screenshot 2023-11-08 at 4 55 12 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/45bfd2d1-f319-47ba-b663-660100e4ebb6">

UserKey and VaultCollection inlines at bottom of User detail page

<img width="1170" alt="Screenshot 2023-11-08 at 4 54 28 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/044592f3-72df-4d65-ad10-a3fb79488cf9">



Closes #35 