### PR TITLE
Signal handler to create a Default VaultCollection when a user signs up

### DIFF
--- a/api/apps.py
+++ b/api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ApiConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'api'
+
+    def ready(self):
+        import api.signals

--- a/api/signals.py
+++ b/api/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import User, VaultCollection
+
+
+@receiver(post_save, sender=User)
+def create_default_vault_collection(sender, instance, created, **kwargs):
+    if created:
+        VaultCollection.objects.create(user=instance, name="Default")

--- a/api/tests/test_create_default_vault_collection.py
+++ b/api/tests/test_create_default_vault_collection.py
@@ -1,0 +1,28 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework.test import APITestCase
+
+from api.models import VaultCollection
+
+
+class TestCreateDefaultVaultCollection(APITestCase):
+    def test_default_vault_collection_created(self):
+        get_user_model().objects.create_user(email="bob@example.com", password="super-secret")
+        all_users = get_user_model().objects.all()
+        self.assertEqual(len(all_users), 1)
+        bob = all_users[0]
+        self.assertEqual(bob.vaultcollection_set.count(), 1)
+        self.assertEqual(VaultCollection.objects.first().name, "Default")
+
+    def test_default_vault_collection_created_signup_api(self):
+        self.client.post(reverse('signup'), {
+            "email": "bob@example.com",
+            "password": "super-secret",
+            "encrypted_symmetric_key": "as0env8as7e0r9akse098a0e98r7aev"
+        })
+        all_users = get_user_model().objects.all()
+        self.assertEqual(len(all_users), 1)
+        bob = all_users[0]
+        self.assertEqual(bob.vaultcollection_set.count(), 1)
+        self.assertEqual(VaultCollection.objects.first().name, "Default")


### PR DESCRIPTION
## Changes

- Create a signal handler that listens for the `post_save` signal on `User` objects.
- Whenever a new user is created, the handler creates a new `VaultCollection` named "Default" for the user.

## Testing

- Unit tests

Closes #17 