### PR TITLE
Add /user_key endpoint and return encrypted_symmetric_key from /login

### DIFF
--- a/api/tests/test_login.py
+++ b/api/tests/test_login.py
@@ -3,20 +3,34 @@ from django.urls import reverse
 
 from rest_framework.test import APITestCase
 
+from api.models import UserKey
+
 
 class TestLoginAPIView(APITestCase):
 
     def setUp(self):
         self.login_url = reverse('login')
+        self.user_key_url = reverse('user_key')
         self.user_data = {
             'email': 'marion@gmail.com',
             'password': 'super-password'
         }
         self.user = get_user_model().objects.create_user(**self.user_data)
+        self.user_key = UserKey.objects.create(
+            user=self.user,
+            encrypted_symmetric_key='somelonggobbledegookthatlookslikeitsabase64encodedstring'
+        )
+        self.no_key_user_data = {
+            'email': 'bob@example.com',
+            'password': 'nobody-can-guess-this'
+        }
+        self.no_key_user = get_user_model().objects.create_user(**self.no_key_user_data)
 
     def test_login_success(self):
         response = self.client.post(self.login_url, self.user_data)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['encrypted_symmetric_key'],
+                         self.user_key.encrypted_symmetric_key)
         self.assertIn('csrftoken', response.cookies)
         self.assertIn('sessionid', response.cookies)
 
@@ -104,3 +118,8 @@ class TestLoginAPIView(APITestCase):
         self.assertIn('This field may not be blank.', response.data['password'])
         self.assertNotIn('csrftoken', response.cookies)
         self.assertNotIn('sessionid', response.cookies)
+
+    def test_login_user_key_not_found(self):
+        response = self.client.post(self.login_url, self.no_key_user_data)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('User\'s symmetric key not found', response.data['detail'])

--- a/api/tests/test_logout.py
+++ b/api/tests/test_logout.py
@@ -4,6 +4,8 @@ from django.urls import reverse
 
 from rest_framework.test import APITestCase
 
+from api.models import UserKey
+
 
 class TestLogoutAPIView(APITestCase):
 
@@ -16,6 +18,10 @@ class TestLogoutAPIView(APITestCase):
             'password': 'super-password'
         }
         self.user = get_user_model().objects.create_user(**self.user_data)
+        self.user_key = UserKey.objects.create(
+            user=self.user,
+            encrypted_symmetric_key='somelonggobbledegookthatlookslikeitsabase64encodedstring'
+        )
 
     def test_logout_success(self):
         response = self.client.post(self.login_url, self.user_data)

--- a/api/tests/test_user_key.py
+++ b/api/tests/test_user_key.py
@@ -1,0 +1,40 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework.test import APITestCase
+
+from api.models import UserKey
+
+
+class TestUserKeyAPIView(APITestCase):
+
+    def setUp(self):
+        self.login_url = reverse('login')
+        self.user_key_url = reverse('user_key')
+        self.user_data = {
+            'email': 'marion@gmail.com',
+            'password': 'super-password'
+        }
+        self.user = get_user_model().objects.create_user(**self.user_data)
+        self.user_key = UserKey.objects.create(
+            user=self.user,
+            encrypted_symmetric_key='somelonggobbledegookthatlookslikeitsabase64encodedstring'
+        )
+        self.no_key_user_data = {
+            'email': 'bob@example.com',
+            'password': 'nobody-can-guess-this'
+        }
+        self.no_key_user = get_user_model().objects.create_user(**self.no_key_user_data)
+
+    def test_user_key_success(self):
+        self.client.post(self.login_url, self.user_data)
+        response = self.client.get(self.user_key_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['encrypted_symmetric_key'],
+                         self.user_key.encrypted_symmetric_key)
+
+    def test_user_key_not_found(self):
+        self.client.login(**self.no_key_user_data)
+        response = self.client.get(self.user_key_url)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('User\'s symmetric key not found', response.data['detail'])

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import LoginAPIView, LogoutAPIView, SignupAPIView, VaultCollectionViewSet, VaultItemViewSet
+from .views import LoginAPIView, LogoutAPIView, SignupAPIView, UserKeyAPIView, \
+    VaultCollectionViewSet, VaultItemViewSet
 
 router = DefaultRouter()
 
@@ -9,6 +10,7 @@ urlpatterns = [
     path('login/', LoginAPIView.as_view(), name='login'),
     path('logout/', LogoutAPIView.as_view(), name='logout'),
     path('signup/', SignupAPIView.as_view(), name='signup'),
+    path('user_key/', UserKeyAPIView.as_view(), name='user_key'),
 ]
 
 router.register(r'vault_items', VaultItemViewSet, basename='vault_item')

--- a/api/views.py
+++ b/api/views.py
@@ -9,9 +9,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
-from .serializers import LoginSerializer, SignupSerializer, VaultCollectionSerializer, VaultItemSerializer
+from .serializers import LoginSerializer, SignupSerializer, UserKeySerializer, \
+    VaultCollectionSerializer, VaultItemSerializer
 
-from api.models import VaultItem, VaultCollection
+from api.models import UserKey, VaultItem, VaultCollection
 
 
 class LoginAPIView(APIView):
@@ -25,7 +26,10 @@ class LoginAPIView(APIView):
 
         user = serializer.validated_data['user']
         login(request, user)
-        return Response(status=status.HTTP_200_OK)
+
+        payload = serializer.validated_data['user_key']
+
+        return Response(data=payload, status=status.HTTP_200_OK)
 
 
 class LogoutAPIView(APIView):
@@ -41,6 +45,19 @@ class SignupAPIView(CreateAPIView):
 
     model = get_user_model()
     serializer_class = SignupSerializer
+
+
+class UserKeyAPIView(APIView):
+
+    def get(self, request):
+        try:
+            user_key = UserKey.objects.get(user=request.user.id)
+        except ObjectDoesNotExist:
+            raise PermissionDenied("User's symmetric key not found")
+
+        serializer = UserKeySerializer(user_key)
+
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
 class VaultItemViewSet(ModelViewSet):


### PR DESCRIPTION
## Changes

- The `/login` endpoint now returns the user's `encrypted_symmetric_key` in the JSON body of the response
     - If the user doesn't have an associated `UserKey` object, login fails with 403 (if the `UserKey` object doesn't exist, the user may have been created through malicious means like direct database access, not through the application)
- Added a `/user_key` endpoint that returns the user's `encrypted_symmetric_key` if it exists, and a 403 otherwise.

## Testing

- Unit tests
- Manual testing with Postman

1. Login a user with a UserKey

<img width="777" alt="Screenshot 2023-11-21 at 2 43 02 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/43a4c483-f0de-402d-b077-95f3c58eeaf6">

2. Login a user without a UserKey

<img width="771" alt="Screenshot 2023-11-21 at 2 44 41 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/6ef7553d-214b-477f-aae5-5edd04f89151">

3. User with UserKey makes GET request to `/user_key`

<img width="774" alt="Screenshot 2023-11-21 at 2 49 06 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/bb6e6003-e2a7-470c-a39a-31fcdf25e543">

4. User without a UserKey makes GET request to `/user_key`

<img width="772" alt="Screenshot 2023-11-21 at 2 48 28 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/6688ec7d-2c28-442b-ae40-a812a2230dca">

Closes #45 