### PR TITLE
Return 404 Not Found when user references VaultCollection they don't own

### DIFF
--- a/api/tests/test_vault_item.py
+++ b/api/tests/test_vault_item.py
@@ -149,7 +149,7 @@ class TestCreateVaultItemViewSet(APITestCase):
             'encrypted_data': 'encrypted data',
             'vault_collection': self.other_user_vc.uuid
         })
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
         self.assertIn('User does not own VaultCollection',
                       response.data['detail'])
         vault_item = VaultItem.objects.filter(

--- a/api/views.py
+++ b/api/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model, login, logout
 from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -80,8 +80,8 @@ class VaultItemViewSet(ModelViewSet):
                 VaultCollection.objects.get(user_id=self.request.user.id,
                                             uuid=serializer.validated_data['vault_collection'].uuid)
         except ObjectDoesNotExist:
-            raise PermissionDenied(
-                detail='User does not own VaultCollection', code=status.HTTP_403_FORBIDDEN)
+            raise NotFound(
+                detail='User does not own VaultCollection')
 
     def perform_create(self, serializer):
         self.validate_vault_collection(serializer)


### PR DESCRIPTION
Instead of returning 403 when a user references a VaultCollection they don't own, return 404.

403 will be reserved for cases when a user isn't authenticated.

Closes #43 