### PR TITLE
Include vault_collection_name in GET responses at /vault_items/

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework.serializers import Serializer, ModelSerializer, CharField, EmailField, \
-    SlugRelatedField
+    SlugRelatedField, StringRelatedField
 
 from api.models import UserKey, VaultItem, VaultCollection
 
@@ -62,14 +62,15 @@ class VaultItemSerializer(ModelSerializer):
     # JSON payloads would use 'vault_collection' for the uuid field, not 'vault_collection_uuid'
     vault_collection = SlugRelatedField(
         slug_field='uuid', queryset=VaultCollection.objects.all())
+    vault_collection_name = StringRelatedField(source='vault_collection')
 
     class Meta:
         model = VaultItem
         fields = ['encrypted_data', 'uuid',
-                  'vault_collection', 'created_at', 'modified_at']
+                  'vault_collection', 'vault_collection_name', 'created_at', 'modified_at']
 
         # Means that these fields are not expected on write requests but are returned on reads
-        read_only_fields = ['created_at', 'modified_at']
+        read_only_fields = ['created_at', 'modified_at', 'vault_collection_name']
 
 
 class VaultCollectionSerializer(ModelSerializer):

--- a/api/tests/test_vault_item.py
+++ b/api/tests/test_vault_item.py
@@ -38,6 +38,8 @@ class TestCreateVaultItemViewSet(APITestCase):
         vault_item = VaultItem.objects.get(
             vault_collection_id=self.vault_collection.id)
         self.assertEqual(str(vault_item.uuid), response.data['uuid'])
+        self.assertIn('vault_collection_name', response.data)
+        self.assertEqual(response.data['vault_collection_name'], self.vault_collection.name)
         self.assertEqual(vault_item.vault_collection, self.vault_collection)
 
     def test_vault_item_create_vault_collection_uuid_missing(self):


### PR DESCRIPTION
## Changes

- Add `vault_collection_name` field to `VaultItemSerializer` so that the name of the associated VaultCollection is returned with the rest of the VaultItem data

## Testing

- Unit test

- Manual testing with Postman

List response:

<img width="781" alt="Screenshot 2023-11-28 at 12 26 01 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/4e153219-ba54-49b6-9359-b8fdfdd0ece6">

Detail response:

<img width="776" alt="Screenshot 2023-11-28 at 12 27 06 PM" src="https://github.com/secure-password-manager/key-fortress-server/assets/39425112/ca1ddde9-9148-41aa-904d-ea825363c93f">

Closes #51 