### PR TITLE
Set rate limit of 5 requests/day for anonymous users at signup endpoint

### DIFF
--- a/api/throttling.py
+++ b/api/throttling.py
@@ -1,0 +1,8 @@
+from rest_framework.throttling import AnonRateThrottle
+
+
+class SignupAnonRateThrottle(AnonRateThrottle):
+
+    def __init__(self):
+        self.rate = '5/day'
+        super().__init__()

--- a/api/views.py
+++ b/api/views.py
@@ -11,6 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from .serializers import LoginSerializer, SignupSerializer, UserKeySerializer, \
     VaultCollectionSerializer, VaultItemSerializer
+from .throttling import SignupAnonRateThrottle
 
 from api.models import UserKey, VaultItem, VaultCollection
 
@@ -40,6 +41,7 @@ class LogoutAPIView(APIView):
 
 
 class SignupAPIView(CreateAPIView):
+    throttle_classes = [SignupAnonRateThrottle]
     authentication_classes = []
     permission_classes = [AllowAny]
 


### PR DESCRIPTION
Adds a rate limit for anonymous users of 5 requests/day to the /signup endpoint, to prevent attackers from creating unlimited accounts and taking down the DB server.